### PR TITLE
sync of <./rust-k256> to the `halo2`-Poseidon variant

### DIFF
--- a/rust-k256/Cargo.toml
+++ b/rust-k256/Cargo.toml
@@ -6,12 +6,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand_core = "0.6.3"
-hex-literal = "0.3.4"
-hash2field = "0.4.0"
-num-bigint = "0.4.3"
-num-integer = "0.1.45"
-k256 = {version = "0.13.2", features = ["arithmetic", "hash2curve", "expose-field", "sha2"]}
+rand_core = "~0.6.3"
+# hash2field = "0.4.0"
+num-bigint = "~0.4.3"
+num-integer = "~0.1.45"
+k256 = {version = "~0.13.3", features = ["arithmetic", "hash2curve", "expose-field", "sha2"]}
+signature = "^2.2.0"
+serde = { version = "^1.0.0", features = ["derive"], optional = true }
+pse-poseidon = { git = "https://github.com/shreyas-londhe/pse-poseidon.git" }
+halo2curves = "0.6.1"
+halo2curves-axiom = "0.5.3"
 
 [dev-dependencies]
 hex = "0.4.3"
+halo2-plume = { path = "../circuits/halo2" }
+halo2-ecc = { git = "https://github.com/shreyas-londhe/halo2-lib.git", branch = "feat/secp256k1-hash2curve-poseidon", default-features = false, features = ["halo2-axiom"] }
+halo2-base = { git = "https://github.com/shreyas-londhe/halo2-lib.git", branch = "feat/secp256k1-hash2curve-poseidon", default-features = false, features = ["halo2-axiom", "test-utils"] }

--- a/rust-k256/src/lib.rs
+++ b/rust-k256/src/lib.rs
@@ -1,456 +1,607 @@
 // #![feature(generic_const_expr)]
 // #![allow(incomplete_features)]
 
-use k256::{
-    elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest},
-    elliptic_curve::ops::ReduceNonZero,
-    elliptic_curve::sec1::ToEncodedPoint,
-    elliptic_curve::{bigint::ArrayEncoding, group::ff::PrimeField},
-    sha2::{digest::Output, Digest, Sha256},
-    FieldBytes, ProjectivePoint, Scalar, Secp256k1, U256,
-}; // requires 'getrandom' feature
-use std::panic;
+//! A library for generating and verifying PLUME signatures.
+//!
+//! See <https://blog.aayushg.com/nullifier> for more information.
+//!
+// Find `arkworks-rs` crate as `plume_arkworks`.
+//
+//! # Examples
+//! If you want more control or to be more generic on traits `use` [`PlumeSigner`] from [`randomizedsigner`]
+//! ```rust
+//! use plume_rustcrypto::{PlumeSignature, SecretKey};
+//! use rand_core::OsRng;
+//! # fn main() {
+//! #   let sk = SecretKey::random(&mut OsRng);
+//! #       
+//!     let sig_v1 = PlumeSignature::sign_v1(
+//!         &sk, b"ZK nullifier signature", &mut OsRng
+//!     );
+//!     assert!(sig_v1.verify());
+//!
+//!     let sig_v2 = PlumeSignature::sign_v2(
+//!         &sk, b"ZK nullifier signature", &mut OsRng
+//!     );
+//!     assert!(sig_v2.verify());
+//! # }
+//! ```
 
-const L: usize = 48;
-const COUNT: usize = 2;
-const OUT: usize = L * COUNT;
-const DST: &[u8] = b"QUUX-V01-CS02-with-secp256k1_XMD:SHA-256_SSWU_RO_"; // Hash to curve algorithm
+use k256::elliptic_curve::bigint::ArrayEncoding;
+use k256::elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
+use k256::elliptic_curve::ops::Reduce;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::sha2::{digest::Output, Digest, Sha256}; // requires 'getrandom' feature
+use k256::{ProjectivePoint, Secp256k1};
+use k256::Scalar;
+use k256::U256;
+use signature::RandomizedSigner;
 
-fn print_type_of<T>(_: &T) {
-    println!("{}", std::any::type_name::<T>());
+/// Exports types from the `k256` crate:
+///
+/// - `NonZeroScalar`: A secret 256-bit scalar value.
+/// - `SecretKey`: A secret 256-bit scalar wrapped in a struct.  
+/// - `AffinePoint`: A public elliptic curve point.
+pub use k256::{AffinePoint, NonZeroScalar, SecretKey};
+/// Re-exports the [`CryptoRngCore`] trait from the [`rand_core`] crate.
+/// This allows it to be used from the current module.
+pub use rand_core::CryptoRngCore;
+#[cfg(feature = "serde")]
+/// Provides the ability to serialize and deserialize data using the Serde library.
+/// The `Serialize` and `Deserialize` traits from the Serde library are re-exported for convenience.
+pub use serde::{Deserialize, Serialize};
+
+mod utils;
+// not published due to use of `Projective...`; these utils can be found in other crates
+use utils::*;
+
+/// The domain separation tag used for hashing to the `secp256k1` curve
+pub const DST: &[u8] = b"QUUX-V01-CS02-with-secp256k1_XMD:SHA-256_SSWU_RO_"; // Hash to curve algorithm
+
+/// Struct holding signature data for a PLUME signature.
+///
+/// `v1specific` field differintiate whether V1 or V2 protocol will be used.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PlumeSignature {
+    /// The message that was signed.
+    pub message: Vec<u8>,
+    /// The public key used to verify the signature.
+    pub pk: AffinePoint,
+    /// The nullifier.
+    pub nullifier: AffinePoint,
+    /// Part of the signature data. SHA-256 interpreted as a scalar.
+    pub c: NonZeroScalar,
+    /// Part of the signature data, a scalar value.
+    pub s: NonZeroScalar,
 }
-
-fn c_sha256_vec_signal(values: Vec<&ProjectivePoint>) -> Output<Sha256> {
-    let preimage_vec = values
-        .into_iter()
-        .map(encode_pt)
-        .collect::<Vec<_>>()
-        .concat();
-    let mut sha256_hasher = Sha256::new();
-    sha256_hasher.update(preimage_vec.as_slice());
-    sha256_hasher.finalize()
+/// Nested struct holding additional signature data used in variant 1 of the protocol.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PlumeSignatureV1Fields {
+    /// Part of the signature data, a curve point.  
+    pub r_point: AffinePoint,
+    /// Part of the signature data, a curve point.
+    pub hashed_to_curve_r: AffinePoint,
 }
+fn sign_with_rng(
+    sk: NonZeroScalar,
+    rng: &mut impl CryptoRngCore,
+    msg: &[u8],
+) -> PlumeSignature {
+    // Pick a random r from Fp
+    let r_scalar = SecretKey::random(rng);
 
-fn sha256hash6signals(
-    g: &ProjectivePoint,
-    pk: &ProjectivePoint,
-    hash_m_pk: &ProjectivePoint,
-    nullifier: &ProjectivePoint,
-    g_r: &ProjectivePoint,
-    hash_m_pk_pow_r: &ProjectivePoint,
-) -> Scalar {
-    let g_bytes = encode_pt(g);
-    let pk_bytes = encode_pt(pk);
-    let h_bytes = encode_pt(hash_m_pk);
-    let nul_bytes = encode_pt(nullifier);
-    let g_r_bytes = encode_pt(g_r);
-    let z_bytes = encode_pt(hash_m_pk_pow_r);
+    let r_point = r_scalar.public_key();
 
-    let c_preimage_vec = [g_bytes, pk_bytes, h_bytes, nul_bytes, g_r_bytes, z_bytes].concat();
+    let sk = SecretKey::from(sk);
+    let pk = sk.public_key();
 
-    //println!("c_preimage_vec: {:?}", c_preimage_vec);
+    let pk_bytes = pk.to_encoded_point(true).to_bytes();
 
-    let mut sha256_hasher = Sha256::new();
-    sha256_hasher.update(c_preimage_vec.as_slice());
-    let sha512_hasher_result = sha256_hasher.finalize(); //512 bit hash
+    let hashed_to_curve = 
+        Secp256k1::hash_from_bytes::<ExpandMsgXmd<pse_poseidon::Poseidon<
+            halo2curves_axiom::bn256::Fr, 3, 2
+        >>>(
+            &[[msg, &pk_bytes].concat().as_slice()],
+            &[b"QUUX-V01-CS02-with-secp256k1_XMD:POSEIDON_SSWU_RO_"]
+        )
+        .unwrap()
+        .to_affine();
+    // let hashed_to_curve = hashed_to_curve.to_encoded_point(false).to_bytes().into_vec();
+    // assert_eq!(hashed_to_curve.len(), 65);
 
-    let c_bytes = FieldBytes::from_iter(sha512_hasher_result.iter().copied());
-    Scalar::from_repr(c_bytes).unwrap()
-}
+    // let mut x = hashed_to_curve[1..33].to_vec();
+    // x.reverse();
+    // let mut y = hashed_to_curve[33..].to_vec();
+    // y.reverse();
 
-// Hashes two values to the curve
-fn hash_to_curve(
-    m: &[u8],
-    pk: &ProjectivePoint,
-) -> Result<ProjectivePoint, k256::elliptic_curve::Error> {
-    Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(
-        &[[m, &encode_pt(pk)].concat().as_slice()],
-        //b"CURVE_XMD:SHA-256_SSWU_RO_",
-        &[DST],
-    )
-}
+    // let hashed_to_curve = Secp256k1Affine::from_xy(
+    //     Fp::from_bytes_le(x.as_slice()),
+    //     Fp::from_bytes_le(y.as_slice())
+    // ).unwrap();
 
-/* currently seems to right place for this `struct` declaration;
-should be moved (to the beginning of the file?) during refactoring for proper order of the items */
-/* while no consistent #API is present here it's completely `pub`;
-when API will be designed it should include this `struct` (and it also probably will hold values instead of references) */
-pub struct PlumeSignature<'a> {
-    pub message: &'a [u8],
-    pub pk: &'a ProjectivePoint,
-    pub nullifier: &'a ProjectivePoint,
-    pub c: &'a [u8],
-    pub s: &'a Scalar,
-    pub v1: Option<PlumeSignatureV1Fields<'a>>,
-}
-pub struct PlumeSignatureV1Fields<'a> {
-    pub r_point: &'a ProjectivePoint,
-    pub hashed_to_curve_r: &'a ProjectivePoint,
-}
-impl PlumeSignature<'_> {
-    // Verifier check in SNARK:
-    // g^[r + sk * c] / (g^sk)^c = g^r
-    // hash[m, gsk]^[r + sk * c] / (hash[m, pk]^sk)^c = hash[m, pk]^r
-    // c = hash2(g, g^sk, hash[m, g^sk], hash[m, pk]^sk, gr, hash[m, pk]^r)
-    pub fn verify_signals(&self) -> bool {
-        // don't forget to check `c` is `Output<Sha256>` in the #API
-        let c = panic::catch_unwind(|| Output::<Sha256>::from_slice(self.c));
-        if c.is_err() {
-            return false;
-        }
-        let c = c.unwrap();
+    let hashed_to_curve_sk = (hashed_to_curve * *sk.to_nonzero_scalar()).to_affine();
 
-        // TODO should we allow `c` input greater than BaseField::MODULUS?
-        // TODO `reduce_nonzero` doesn't seems to be correct here. `NonZeroScalar` should be appropriate.
-        let c_scalar = &Scalar::reduce_nonzero(U256::from_be_byte_array(c.to_owned()));
+    // it feels not that scary to store `r_scalar` as `NonZeroScalar` (compared to `self.secret_key`)
+    let r_scalar = r_scalar.to_nonzero_scalar();
 
-        let r_point = ProjectivePoint::GENERATOR * self.s - self.pk * c_scalar;
+    // Compute z = h^r
+    let hashed_to_curve_r = 
+        (hashed_to_curve * *r_scalar).to_affine();
 
-        let hashed_to_curve = hash_to_curve(self.message, self.pk);
-        if hashed_to_curve.is_err() {
-            return false;
-        }
-        let hashed_to_curve = hashed_to_curve.unwrap();
+    let mut poseidon_hasher = 
+        pse_poseidon::Poseidon::<halo2curves_axiom::bn256::Fr, 3, 2>::new(
+            8, 57
+        );
+    poseidon_hasher.update(
+        &[
+            k256::AffinePoint::GENERATOR.to_encoded_point(true).to_bytes(),
+            pk_bytes,
+            hashed_to_curve.to_encoded_point(true).to_bytes(),
+            hashed_to_curve_sk.to_encoded_point(true).to_bytes(),
+            r_point.to_encoded_point(true).to_bytes(),
+            hashed_to_curve_r.to_encoded_point(true).to_bytes(),
+        ]
+        .concat()
+        .iter()
+        .map(|v| halo2curves_axiom::bn256::Fr::from(*v as u64))
+        .collect::<Vec<halo2curves_axiom::bn256::Fr>>()
+    );
+    // let c = poseidon_hasher.squeeze_and_reset();
+    let mut c_bytes = poseidon_hasher.squeeze_and_reset().to_bytes();
+    c_bytes.reverse();
+    let c_scalar = 
+        NonZeroScalar::from_repr(c_bytes.into())
+        .expect("it should be impossible to get the hash equal to zero");
 
-        let hashed_to_curve_r = hashed_to_curve * self.s - self.nullifier * c_scalar;
+    // Compute $s = r + sk ⋅ c$. #lastoponsecret
+    let s_scalar = 
+        NonZeroScalar::new(
+            *r_scalar + *(c_scalar * sk.to_nonzero_scalar())
+        ).expect("something is terribly wrong if the nonce is equal to negated product of the secret and the hash");
 
-        if let Some(PlumeSignatureV1Fields {
-            r_point: sig_r_point,
-            hashed_to_curve_r: sig_hashed_to_curve_r,
-        }) = self.v1
-        {
-            // Check whether g^r equals g^s * pk^{-c}
-            if &r_point != sig_r_point {
-                return false;
-            }
-
-            // Check whether h^r equals h^{r + sk * c} * nullifier^{-c}
-            if &hashed_to_curve_r != sig_hashed_to_curve_r {
-                return false;
-            }
-
-            // Check if the given hash matches
-            c == &c_sha256_vec_signal(vec![
-                &ProjectivePoint::GENERATOR,
-                self.pk,
-                &hashed_to_curve,
-                self.nullifier,
-                &r_point,
-                &hashed_to_curve_r,
-            ])
-        } else {
-            // Check if the given hash matches
-            c == &c_sha256_vec_signal(vec![self.nullifier, &r_point, &hashed_to_curve_r])
-        }
+    PlumeSignature {
+        message: msg.to_owned(),
+        pk: pk.into(),
+        nullifier: hashed_to_curve_sk,
+        c: c_scalar,
+        s: s_scalar,
     }
-}
-
-/// Encodes the point by compressing it to 33 bytes
-fn encode_pt(point: &ProjectivePoint) -> Vec<u8> {
-    point.to_encoded_point(true).to_bytes().to_vec()
-}
-
-/// Convert a 32-byte array to a scalar
-fn byte_array_to_scalar(bytes: &[u8]) -> Scalar {
-    // From https://docs.rs/ark-ff/0.3.0/src/ark_ff/fields/mod.rs.html#371-393
-    assert!(bytes.len() == 32);
-    let mut res = Scalar::from(0u64);
-    let window_size = Scalar::from(256u64);
-    for byte in bytes.iter() {
-        res *= window_size;
-        res += Scalar::from(*byte as u64);
-    }
-    res
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use halo2_base::gates::RangeInstructions;
+    use halo2_base::poseidon::hasher::spec::OptimizedPoseidonSpec;
+    use halo2_base::poseidon::hasher::PoseidonHasher;
+    use halo2_base::utils::testing::base_test;
+    use halo2_ecc::ecc::EccChip;
+    use halo2_ecc::fields::FieldChip;
+    use halo2_ecc::secp256k1::{FpChip, FqChip};
+    use halo2_plume::{verify_plume, PlumeInput};
+    use halo2curves::CurveAffine;
+    use halo2curves_axiom::bn256::Fr;
+    use rand_core::OsRng;
+    use k256::elliptic_curve::point::AffineCoordinates;
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use halo2_base::utils::ScalarField;
 
-    use helpers::{gen_test_scalar_sk, hash_to_secp, test_gen_signals, PlumeVersion};
-    mod helpers {
-        use super::*;
-        use hex_literal::hex;
-
-        #[derive(Debug)]
-        pub enum PlumeVersion {
-            V1,
-            V2,
-        }
-
-        // Generates a deterministic secret key for deterministic testing. Should be replaced by random oracle in production deployments.
-        pub fn gen_test_scalar_sk() -> Scalar {
-            Scalar::from_repr(
-                hex!("519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464").into(),
-            )
-            .unwrap()
-        }
-
-        // Generates a deterministic r for deterministic testing. Should be replaced by random oracle in production deployments.
-        fn gen_test_scalar_r() -> Scalar {
-            Scalar::from_repr(
-                hex!("93b9323b629f251b8f3fc2dd11f4672c5544e8230d493eceea98a90bda789808").into(),
-            )
-            .unwrap()
-        }
-
-        // Calls the hash to curve function for secp256k1, and returns the result as a ProjectivePoint
-        pub fn hash_to_secp(s: &[u8]) -> ProjectivePoint {
-            let pt: ProjectivePoint = Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(
-                &[s],
-                //b"CURVE_XMD:SHA-256_SSWU_RO_"
-                &[DST],
-            )
-            .unwrap();
-            pt
-        }
-
-        // These generate test signals as if it were passed from a secure enclave to wallet. Note that leaking these signals would leak pk, but not sk.
-        // Outputs these 6 signals, in this order
-        // g^sk																(private)
-        // hash[m, pk]^sk 													public nullifier
-        // c = hash2(g, pk, hash[m, pk], hash[m, pk]^sk, gr, hash[m, pk]^r)	(public or private)
-        // r + sk * c														(public or private)
-        // g^r																(private, optional)
-        // hash[m, pk]^r													(private, optional)
-        pub fn test_gen_signals(
-            m: &[u8],
-            version: PlumeVersion,
-        ) -> (
-            ProjectivePoint,
-            ProjectivePoint,
-            Output<Sha256>,
-            Scalar,
-            Option<ProjectivePoint>,
-            Option<ProjectivePoint>,
-        ) {
-            // The base point or generator of the curve.
-            let g = ProjectivePoint::GENERATOR;
-
-            // The signer's secret key. It is only accessed within the secure enclave.
-            let sk = gen_test_scalar_sk();
-
-            // A random value r. It is only accessed within the secure enclave.
-            let r = gen_test_scalar_r();
-
-            // The user's public key: g^sk.
-            let pk = &g * &sk;
-
-            // The generator exponentiated by r: g^r.
-            let g_r = &g * &r;
-
-            // hash[m, pk]
-            let hash_m_pk = hash_to_curve(m, &pk).unwrap();
-
-            println!(
-                "h.x: {:?}",
-                hex::encode(hash_m_pk.to_affine().to_encoded_point(false).x().unwrap())
+    #[test]
+    fn test_plume_verify() {
+        let msg_str =
+          b"vulputate ut pharetra tis amet aliquam id diam maecenas ultricies mi eget mauris pharetra et adasdds";
+    
+        let mut rng = OsRng;
+        // the only change is `test_data` to switch to the synced part
+        let test_data = 
+            super::sign_with_rng(
+                k256::NonZeroScalar::random(& mut rng), &mut rng, msg_str
             );
-            println!(
-                "h.y: {:?}",
-                hex::encode(hash_m_pk.to_affine().to_encoded_point(false).y().unwrap())
-            );
+        let test_data = halo2_plume::PlumeCircuitInput{ 
+            nullifier: 
+            {
+                let result = test_data.nullifier.to_encoded_point(false).to_bytes().into_vec();
+                assert_eq!(result.len(), 65);
 
-            // hash[m, pk]^r
-            let hash_m_pk_pow_r = &hash_m_pk * &r;
-            println!(
-                "hash_m_pk_pow_r.x: {:?}",
-                hex::encode(
-                    hash_m_pk_pow_r
-                        .to_affine()
-                        .to_encoded_point(false)
-                        .x()
-                        .unwrap()
+                let mut x = result[1..33].to_vec();
+                x.reverse();
+                let mut y = result[33..].to_vec();
+                y.reverse();
+                let result = halo2curves_axiom::secp256k1::Secp256k1Affine::from_xy(
+                    halo2curves_axiom::secp256k1::Fp::from_bytes_le(x.as_slice()),
+                    halo2curves_axiom::secp256k1::Fp::from_bytes_le(y.as_slice())
+                ).unwrap();
+                (result.x, result.y)
+            }, 
+            s: {
+                let mut result = test_data.s.to_bytes().to_vec();
+                assert!(result.len() == 32);
+                result.reverse();
+                let result: [u8; 32] = result.try_into().unwrap();
+                halo2curves_axiom::secp256k1::Fq::from_bytes(&result).unwrap()
+            }, 
+            c: {
+                let mut result = test_data.c.to_bytes().to_vec();
+                assert!(result.len() == 32);
+                result.reverse();
+                let result: [u8; 32] = result.try_into().unwrap();
+                halo2curves_axiom::secp256k1::Fq::from_bytes(&result).unwrap()
+            }, 
+            pk: {
+                let mut result = 
+                    (test_data.pk.x().to_vec(), test_data.pk.to_encoded_point(false).y().unwrap().to_vec());
+                assert!(result.0.len() == 32 && result.1.len() == 32);
+                result.0.reverse();
+                result.1.reverse();
+                let result: ([u8; 32], [u8; 32]) = (result.0.try_into().unwrap(), result.1.try_into().unwrap());
+                (
+                    halo2curves_axiom::secp256k1::Fp::from_bytes(&result.0).unwrap(),
+                    halo2curves_axiom::secp256k1::Fp::from_bytes(&result.1).unwrap(),
                 )
-            );
-            println!(
-                "hash_m_pk_pow_r.y: {:?}",
-                hex::encode(
-                    hash_m_pk_pow_r
-                        .to_affine()
-                        .to_encoded_point(false)
-                        .y()
-                        .unwrap()
-                )
-            );
+            }, 
+            m: test_data.message.iter()
+                .map(|b| halo2curves_axiom::bn256::Fr::from(*b as u64))
+                .collect::<Vec<_>>()
+        };
+    
+        base_test()
+        .k(16)
+        .lookup_bits(15)
+        .expect_satisfied(true)
+        .run(|ctx, range| {
+            let fp_chip = FpChip::<Fr>::new(range, 88, 3);
+            let fq_chip = FqChip::<Fr>::new(range, 88, 3);
+            let ecc_chip = EccChip::<Fr, FpChip<Fr>>::new(&fp_chip);
 
-            // The public nullifier: hash[m, pk]^sk.
-            let nullifier = &hash_m_pk * &sk;
+            let mut poseidon_hasher = PoseidonHasher::<Fr, 3, 2>::new(
+                OptimizedPoseidonSpec::new::<8, 57, 0>()
+            );
+            poseidon_hasher.initialize_consts(ctx, range.gate());
 
-            // The Fiat-Shamir type step.
-            let c = match version {
-                PlumeVersion::V1 => c_sha256_vec_signal(vec![
-                    &g,
-                    &pk,
-                    &hash_m_pk,
-                    &nullifier,
-                    &g_r,
-                    &hash_m_pk_pow_r,
-                ]),
-                PlumeVersion::V2 => c_sha256_vec_signal(vec![&nullifier, &g_r, &hash_m_pk_pow_r]),
+            let nullifier = ecc_chip.load_private_unchecked(ctx, (
+                test_data.nullifier.0,
+                test_data.nullifier.1,
+            ));
+            let s = fq_chip.load_private(ctx, test_data.s);
+            let c = fq_chip.load_private(ctx, test_data.c);
+            let pk = ecc_chip.load_private_unchecked(ctx, (test_data.pk.0, test_data.pk.1));
+            let m = test_data.m
+                .iter()
+                .map(|m| ctx.load_witness(*m))
+                .collect::<Vec<_>>();
+
+            let plume_input = PlumeInput {
+                nullifier,
+                s,
+                c,
+                pk,
+                m,
             };
-            dbg!(&c, version);
 
-            let c_scalar = &Scalar::reduce_nonzero(U256::from_be_byte_array(c.to_owned()));
-            // This value is part of the discrete log equivalence (DLEQ) proof.
-            let r_sk_c = r + sk * c_scalar;
-
-            // Return the signature.
-            (pk, nullifier, c, r_sk_c, Some(g_r), Some(hash_m_pk_pow_r))
-        }
-    }
-
-    #[test]
-    fn plume_v1_test() {
-        let g = ProjectivePoint::GENERATOR;
-
-        let m = b"An example app message string";
-
-        // Fixed key nullifier, secret key, and random value for testing
-        // Normally a secure enclave would generate these values, and output to a wallet implementation
-        let (pk, nullifier, c, r_sk_c, g_r, hash_m_pk_pow_r) =
-            test_gen_signals(m, PlumeVersion::V1);
-
-        // The signer's secret key. It is only accessed within the secure enclave.
-        let sk = gen_test_scalar_sk();
-
-        // The user's public key: g^sk.
-        let pk = &g * &sk;
-
-        // Verify the signals, normally this would happen in ZK with only the nullifier public, which would have a zk verifier instead
-        // The wallet should probably run this prior to snarkify-ing as a sanity check
-        // m and nullifier should be public, so we can verify that they are correct
-        let verified = PlumeSignature {
-            message: m,
-            pk: &pk,
-            nullifier: &nullifier,
-            c: &c,
-            s: &r_sk_c,
-            v1: Some(PlumeSignatureV1Fields {
-                r_point: &g_r.unwrap(),
-                hashed_to_curve_r: &hash_m_pk_pow_r.unwrap(),
-            }),
-        }
-        .verify_signals();
-        println!("Verified: {}", verified);
-
-        // Print nullifier
-        println!(
-            "nullifier.x: {:?}",
-            hex::encode(nullifier.to_affine().to_encoded_point(false).x().unwrap())
-        );
-        println!(
-            "nullifier.y: {:?}",
-            hex::encode(nullifier.to_affine().to_encoded_point(false).y().unwrap())
-        );
-
-        // Print c
-        println!("c: {:?}", hex::encode(&c));
-
-        // Print r_sk_c
-        println!("r_sk_c: {:?}", hex::encode(r_sk_c.to_bytes()));
-
-        // Print g_r
-        println!(
-            "g_r.x: {:?}",
-            hex::encode(
-                g_r.unwrap()
-                    .to_affine()
-                    .to_encoded_point(false)
-                    .x()
-                    .unwrap()
-            )
-        );
-        println!(
-            "g_r.y: {:?}",
-            hex::encode(
-                g_r.unwrap()
-                    .to_affine()
-                    .to_encoded_point(false)
-                    .y()
-                    .unwrap()
-            )
-        );
-
-        // Print hash_m_pk_pow_r
-        println!(
-            "hash_m_pk_pow_r.x: {:?}",
-            hex::encode(
-                hash_m_pk_pow_r
-                    .unwrap()
-                    .to_affine()
-                    .to_encoded_point(false)
-                    .x()
-                    .unwrap()
-            )
-        );
-        println!(
-            "hash_m_pk_pow_r.y: {:?}",
-            hex::encode(
-                hash_m_pk_pow_r
-                    .unwrap()
-                    .to_affine()
-                    .to_encoded_point(false)
-                    .y()
-                    .unwrap()
-            )
-        );
-
-        // Test encode_pt()
-        let g_as_bytes = encode_pt(&g);
-        assert_eq!(
-            hex::encode(g_as_bytes),
-            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
-        );
-
-        // Test byte_array_to_scalar()
-        let scalar = byte_array_to_scalar(&c); // TODO this `fn` looks suspicious as in reproducing const time ops
-        assert_eq!(
-            hex::encode(scalar.to_bytes()),
-            "c6a7fc2c926ddbaf20731a479fb6566f2daa5514baae5223fe3b32edbce83254"
-        );
-
-        // Test the hash-to-curve algorithm
-        let h = hash_to_secp(b"abc");
-        assert_eq!(
-            hex::encode(h.to_affine().to_encoded_point(false).x().unwrap()),
-            "3377e01eab42db296b512293120c6cee72b6ecf9f9205760bd9ff11fb3cb2c4b"
-        );
-        assert_eq!(
-            hex::encode(h.to_affine().to_encoded_point(false).y().unwrap()),
-            "7f95890f33efebd1044d382a01b1bee0900fb6116f94688d487c6c7b9c8371f6"
-        );
-        assert!(verified);
-    }
-
-    #[test]
-    fn plume_v2_test() {
-        let g = ProjectivePoint::GENERATOR;
-
-        let m = b"An example app message string";
-
-        // Fixed key nullifier, secret key, and random value for testing
-        // Normally a secure enclave would generate these values, and output to a wallet implementation
-        let (pk, nullifier, c, r_sk_c, g_r, hash_m_pk_pow_r) =
-            test_gen_signals(m, PlumeVersion::V2);
-
-        // The signer's secret key. It is only accessed within the secu`re enclave.
-        let sk = gen_test_scalar_sk();
-
-        // The user's public key: g^sk.
-        let pk = &g * &sk;
-
-        // Verify the signals, normally this would happen in ZK with only the nullifier public, which would have a zk verifier instead
-        // The wallet should probably run this prior to snarkify-ing as a sanity check
-        // m and nullifier should be public, so we can verify that they are correct
-        let verified = PlumeSignature {
-            message: m,
-            pk: &pk,
-            nullifier: &nullifier,
-            c: &c,
-            s: &r_sk_c,
-            v1: None,
-        }
-        .verify_signals();
-        assert!(verified)
-    }
+            verify_plume::<Fr>(ctx, &ecc_chip, &poseidon_hasher, 4, 4, plume_input)
+        });
+      }
 }
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use hex_literal::hex;
+
+//     pub fn verify_nullifier(
+//         message: &[u8],
+//         nullifier: &Secp256k1Affine,
+//         pk: &Secp256k1Affine,
+//         s: &Fq,
+//         c: &Fq
+//       ) {
+//         let compressed_pk = compress_point(&pk);
+//         let hashed_to_curve = hash_to_curve(message, &compressed_pk);
+//         let hashed_to_curve_s_nullifier_c = (hashed_to_curve * s - nullifier * c).to_affine();
+//         let gs_pkc = (Secp256k1::generator() * s - pk * c).to_affine();
+      
+//         let mut poseidon_hasher = Poseidon::<Fr, 3, 2>::new(8, 57);
+//         poseidon_hasher.update(
+//           &[
+//             compress_point(&Secp256k1::generator().to_affine()),
+//             compressed_pk,
+//             compress_point(&hashed_to_curve),
+//             compress_point(&nullifier),
+//             compress_point(&gs_pkc),
+//             compress_point(&hashed_to_curve_s_nullifier_c),
+//           ]
+//             .concat()
+//             .iter()
+//             .map(|v| Fr::from(*v as u64))
+//             .collect::<Vec<Fr>>()
+//         );
+      
+//         let mut _c = poseidon_hasher.squeeze_and_reset();
+      
+//         let _c = Fq::from_bytes_le(&_c.to_bytes_le());
+      
+//         assert_eq!(*c, _c);
+//       }
+      
+//       pub fn gen_test_nullifier(sk: &Fq, message: &[u8]) -> (Secp256k1Affine, Fq, Fq) {
+//         let pk = (Secp256k1::generator() * sk).to_affine();
+//         let compressed_pk = compress_point(&pk);
+      
+//         let hashed_to_curve = hash_to_curve(message, &compressed_pk);
+      
+//         let hashed_to_curve_sk = (hashed_to_curve * sk).to_affine();
+      
+//         let r = Fq::random(OsRng);
+//         let g_r = (Secp256k1::generator() * r).to_affine();
+//         let hashed_to_curve_r = (hashed_to_curve * r).to_affine();
+      
+//         let mut poseidon_hasher = Poseidon::<Fr, 3, 2>::new(8, 57);
+//         poseidon_hasher.update(
+//           &[
+//             compress_point(&Secp256k1::generator().to_affine()),
+//             compressed_pk,
+//             compress_point(&hashed_to_curve),
+//             compress_point(&hashed_to_curve_sk),
+//             compress_point(&g_r),
+//             compress_point(&hashed_to_curve_r),
+//           ]
+//             .concat()
+//             .iter()
+//             .map(|v| Fr::from(*v as u64))
+//             .collect::<Vec<Fr>>()
+//         );
+      
+//         let c = poseidon_hasher.squeeze_and_reset();
+      
+//         let c = Fq::from_bytes_le(&c.to_bytes_le());
+//         let s = r + sk * c;
+      
+//         (hashed_to_curve_sk, s, c)
+//       }
+      
+//       pub fn generate_test_data(msg: &[u8]) -> PlumeCircuitInput {
+//         let m = msg
+//           .iter()
+//           .map(|b| Fr::from(*b as u64))
+//           .collect::<Vec<_>>();
+      
+//         let sk = Fq::random(OsRng);
+//         let pk = Secp256k1Affine::from(Secp256k1::generator() * sk);
+//         let (nullifier, s, c) = gen_test_nullifier(&sk, msg);
+//         verify_nullifier(msg, &nullifier, &pk, &s, &c);
+      
+//         PlumeCircuitInput {
+//           nullifier: (nullifier.x, nullifier.y),
+//           s,
+//           c,
+//           pk: (pk.x, pk.y),
+//           m,
+//         }
+//       }
+
+//       #[test]
+//       fn test_plume_verify() {
+//         // Inputs
+//         let msg_str =
+//           b"vulputate ut pharetra tis amet aliquam id diam maecenas ultricies mi eget mauris pharetra et adasdds";
+    
+//         let test_data = generate_test_data(msg_str);
+    
+//         base_test()
+//           .k(16)
+//           .lookup_bits(15)
+//           .expect_satisfied(true)
+//           .run(|ctx, range| {
+//             let fp_chip = FpChip::<Fr>::new(range, 88, 3);
+//             let fq_chip = FqChip::<Fr>::new(range, 88, 3);
+//             let ecc_chip = EccChip::<Fr, FpChip<Fr>>::new(&fp_chip);
+    
+//             let mut poseidon_hasher = PoseidonHasher::<Fr, 3, 2>::new(
+//               OptimizedPoseidonSpec::new::<8, 57, 0>()
+//             );
+//             poseidon_hasher.initialize_consts(ctx, range.gate());
+    
+//             let nullifier = ecc_chip.load_private_unchecked(ctx, (
+//               test_data.nullifier.0,
+//               test_data.nullifier.1,
+//             ));
+//             let s = fq_chip.load_private(ctx, test_data.s);
+//             let c = fq_chip.load_private(ctx, test_data.c);
+//             let pk = ecc_chip.load_private_unchecked(ctx, (test_data.pk.0, test_data.pk.1));
+//             let m = test_data.m
+//               .iter()
+//               .map(|m| ctx.load_witness(*m))
+//               .collect::<Vec<_>>();
+    
+//             let plume_input = PlumeInput {
+//               nullifier,
+//               s,
+//               c,
+//               pk,
+//               m,
+//             };
+    
+            
+//           });
+          
+//           plume_input.verify::<Fr>(ctx, &ecc_chip, &poseidon_hasher, 4, 4)
+//       }
+    
+//     // Test encode_pt()
+//     #[test]
+//     fn test_encode_pt() {
+//         let g_as_bytes = encode_pt(&ProjectivePoint::GENERATOR);
+//         assert_eq!(
+//             hex::encode(g_as_bytes),
+//             "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+//         );
+//     }
+
+// /// Convert a 32-byte array to a scalar
+// fn byte_array_to_scalar(bytes: &[u8]) -> Scalar {
+//     // From https://docs.rs/ark-ff/0.3.0/src/ark_ff/fields/mod.rs.html#371-393
+//     assert!(bytes.len() == 32);
+//     let mut res = Scalar::from(0u64);
+//     let window_size = Scalar::from(256u64);
+//     for byte in bytes.iter() {
+//         res *= window_size;
+//         res += Scalar::from(*byte as u64);
+//     }
+//     res
+// }
+
+//     // Test byte_array_to_scalar()
+//     #[test]
+//     fn plume_v1_test() {
+//         let g = ProjectivePoint::GENERATOR;
+
+//         let m = b"An example app message string";
+
+//         // Fixed key nullifier, secret key, and random value for testing
+//         // Normally a secure enclave would generate these values, and output to a wallet implementation
+//         let (pk, nullifier, c, r_sk_c, g_r, hash_m_pk_pow_r) =
+//             test_gen_signals(m, PlumeVersion::V1);
+
+//         // The signer's secret key. It is only accessed within the secure enclave.
+//         let sk = gen_test_scalar_sk();
+
+//         // The user's public key: g^sk.
+//         let pk = &g * &sk;
+
+//         // Verify the signals, normally this would happen in ZK with only the nullifier public, which would have a zk verifier instead
+//         // The wallet should probably run this prior to snarkify-ing as a sanity check
+//         // m and nullifier should be public, so we can verify that they are correct
+//         let verified = PlumeSignature {
+//             message: m,
+//             pk: &pk,
+//             nullifier: &nullifier,
+//             c: &c,
+//             s: &r_sk_c,
+//             v1: Some(PlumeSignatureV1Fields {
+//                 r_point: &g_r.unwrap(),
+//                 hashed_to_curve_r: &hash_m_pk_pow_r.unwrap(),
+//             }),
+//         }
+//         .verify_signals();
+//         println!("Verified: {}", verified);
+
+//         // Print nullifier
+//         println!(
+//             "nullifier.x: {:?}",
+//             hex::encode(nullifier.to_affine().to_encoded_point(false).x().unwrap())
+//         );
+//         println!(
+//             "nullifier.y: {:?}",
+//             hex::encode(nullifier.to_affine().to_encoded_point(false).y().unwrap())
+//         );
+
+//         // Print c
+//         println!("c: {:?}", hex::encode(&c));
+
+//         // Print r_sk_c
+//         println!("r_sk_c: {:?}", hex::encode(r_sk_c.to_bytes()));
+
+//         // Print g_r
+//         println!(
+//             "g_r.x: {:?}",
+//             hex::encode(
+//                 g_r.unwrap()
+//                     .to_affine()
+//                     .to_encoded_point(false)
+//                     .x()
+//                     .unwrap()
+//             )
+//         );
+//         println!(
+//             "g_r.y: {:?}",
+//             hex::encode(
+//                 g_r.unwrap()
+//                     .to_affine()
+//                     .to_encoded_point(false)
+//                     .y()
+//                     .unwrap()
+//             )
+//         );
+
+//         // Print hash_m_pk_pow_r
+//         println!(
+//             "hash_m_pk_pow_r.x: {:?}",
+//             hex::encode(
+//                 hash_m_pk_pow_r
+//                     .unwrap()
+//                     .to_affine()
+//                     .to_encoded_point(false)
+//                     .x()
+//                     .unwrap()
+//             )
+//         );
+//         println!(
+//             "hash_m_pk_pow_r.y: {:?}",
+//             hex::encode(
+//                 hash_m_pk_pow_r
+//                     .unwrap()
+//                     .to_affine()
+//                     .to_encoded_point(false)
+//                     .y()
+//                     .unwrap()
+//             )
+//         );
+
+//         // Test encode_pt()
+//         let g_as_bytes = encode_pt(&g);
+//         assert_eq!(
+//             hex::encode(g_as_bytes),
+//             "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+//         );
+
+//         // Test byte_array_to_scalar()
+//         let scalar = byte_array_to_scalar(&c); // TODO this `fn` looks suspicious as in reproducing const time ops
+//         assert_eq!(
+//             hex::encode(scalar.to_bytes()),
+//             "c6a7fc2c926ddbaf20731a479fb6566f2daa5514baae5223fe3b32edbce83254"
+//         );
+
+//         // Test the hash-to-curve algorithm
+//         let h = hash_to_secp(b"abc");
+//         assert_eq!(
+//             hex::encode(h.to_affine().to_encoded_point(false).x().unwrap()),
+//             "3377e01eab42db296b512293120c6cee72b6ecf9f9205760bd9ff11fb3cb2c4b"
+//         );
+//         assert_eq!(
+//             hex::encode(h.to_affine().to_encoded_point(false).y().unwrap()),
+//             "7f95890f33efebd1044d382a01b1bee0900fb6116f94688d487c6c7b9c8371f6"
+//         );
+//         assert!(verified);
+//     }
+
+//     #[test]
+//     fn plume_v2_test() {
+//         let g = ProjectivePoint::GENERATOR;
+
+//         let m = b"An example app message string";
+
+//         // Fixed key nullifier, secret key, and random value for testing
+//         // Normally a secure enclave would generate these values, and output to a wallet implementation
+//         let (pk, nullifier, c, r_sk_c, g_r, hash_m_pk_pow_r) =
+//             test_gen_signals(m, PlumeVersion::V2);
+
+//         // The signer's secret key. It is only accessed within the secu`re enclave.
+//         let sk = gen_test_scalar_sk();
+
+//         // The user's public key: g^sk.
+//         let pk = &g * &sk;
+
+//         // Verify the signals, normally this would happen in ZK with only the nullifier public, which would have a zk verifier instead
+//         // The wallet should probably run this prior to snarkify-ing as a sanity check
+//         // m and nullifier should be public, so we can verify that they are correct
+//         let verified = PlumeSignature {
+//             message: m,
+//             pk: &pk,
+//             nullifier: &nullifier,
+//             c: &c,
+//             s: &r_sk_c,
+//             v1: None,
+//         }
+//         .verify_signals();
+//         assert!(verified)
+//     }
+// }


### PR DESCRIPTION
Here's sync of <./rust-k256> to the `halo2`-Poseidon variant. I'd be happy to improve that; currently there're two reasons it end up being quite lame: I'm intuitively missing the point of the sync (and have no guideline on the hand), and there's bunch of places I feel do need quite some scrutiny before those got a developed implementation.

This lets generate Plume sigs without using `halo2` which then can be verified with `halo2`.

Here's snippet I started with; it turned out I took a more superficial approach to the sync now. That contains my initial concerns which are still valid since that early stage I started to look into this.
```rust
// Compute h = htc([m, pk])
// why don't we just _map_ Poseidon output here?
let hashed_to_curve = NonIdentity::new(
    /* @yush_g > So I think your main goal should just be getting that to match
    @skaunov [In reply to Shreyas Londhe]
    >> I started to match/sync (as @yush_g explained to me), and I feel that it maps a BN254 base field element to a secp256k1 point which doesn't feel right to me. Should I just continue or is it an oversight?
    >>
    >> Also why don't we just map Poseidon output to the curve (without expanding) *if* it's a RO?
    @shreyaslondhe
    >>> Hi @skaunov I have a test which uses the poseidon hash fn with hash2curve, you can find the code here - https://github.com/shreyas-londhe/zk-nullifier-sig/blob/feat/plume-halo2/circuits/halo2/src/utils.rs#L36-L39
    >>>
    >>> Can you please update your tests accordingly please? */
    Secp256k1::hash_from_bytes::<ExpandMsgXmd<pse_poseidon::Poseidon<
        // halo2_base::halo2_proofs::
            halo2curves::bn256::Fr,
        3,
        2
    >
>>(&[msg, &pk_bytes], &[DST])
        .map_err(|_| Error::new())?,
)
.expect("something is drammatically wrong if the input hashed to the identity");
```